### PR TITLE
Request Animation frame after all details opened

### DIFF
--- a/src/vaadin-grid-row-details-mixin.html
+++ b/src/vaadin-grid-row-details-mixin.html
@@ -96,6 +96,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this._a11yUpdateRowDetailsOpened(row, this._isDetailsOpened(row._item));
         this._toggleAttribute('details-opened', this._isDetailsOpened(row._item), row);
       });
+      requestAnimationFrame(() => this.notifyResize());
     }
 
     _configureDetailsCell(cell) {
@@ -130,9 +131,6 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           Polymer.flush();
-          row.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
-
-          requestAnimationFrame(() => this.notifyResize());
         }
       }
       if (hiddenChanged) {


### PR DESCRIPTION
This provides about a 50% performance increase when `detailsOpenedItems.length` has a large change. Previously a resize/paint cycle was hitting for each row that was changed. This now waits to call `requestAnimationFrame` until all rows have been processed. Showing details on 100 rows went from 5+ seconds to 2+ seconds. Previously these calls were getting sucked up by the debouncer and then run sequentially.
```
row.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
```
was redundant as ` _resizeHandler()` (and therefore `_updateDetailsCellHeights()`) in `vaadin-grid` is going to get called anyways when the details cell is hidden or shown.